### PR TITLE
Proposal: Switch Attrs to BTreeMap

### DIFF
--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -284,3 +284,25 @@ fn test_creation_with_no_xml_prolog_defined() {
             </list>\
         </mydoc>");
 }
+
+#[test]
+fn test_render_multiple_times() {
+    let mut root = Element::new("{demo}mydoc");
+    root.set_namespace_prefix("demo", "").unwrap();
+    root.set_attr(("demo", "id"), "some_id".to_string())
+        .set_attr(("demo", "name"), "some_name".to_string())
+        .set_attr(("demo", "some-other-attr"), "other_attr".to_string());
+
+    let mut out:Vec<u8> = Vec::new();
+
+    root.to_writer_with_options(&mut out, WriteOptions::new()).unwrap();
+    assert_eq!(str::from_utf8(&out).unwrap(), "\
+        <?xml version=\"1.0\" encoding=\"utf-8\"?>\
+        <mydoc xmlns=\"demo\" id=\"some_id\" name=\"some_name\" some-other-attr=\"other_attr\" />");
+
+    let mut out2:Vec<u8> = Vec::new();
+    root.to_writer_with_options(&mut out2, WriteOptions::new()).unwrap();
+    assert_eq!(str::from_utf8(&out2).unwrap(), "\
+        <?xml version=\"1.0\" encoding=\"utf-8\"?>\
+        <mydoc xmlns=\"demo\" id=\"some_id\" name=\"some_name\" some-other-attr=\"other_attr\" />");
+}


### PR DESCRIPTION
In order to render the same XML every time (when using same inputs and options) we need to switch from HashMap to BTreeMap.

Problem:
```rust
 let mut root = Element::new("{demo}mydoc");
    root.set_namespace_prefix("demo", "").unwrap();
    root.set_attr(("demo", "id"), "some_id".to_string())
        .set_attr(("demo", "name"), "some_name".to_string())
        .set_attr(("demo", "some-other-attr"), "other_attr".to_string());

    let mut out:Vec<u8> = Vec::new();

    root.to_writer_with_options(&mut out, WriteOptions::new()).unwrap();
    assert_eq!(str::from_utf8(&out).unwrap(), "\
        <?xml version=\"1.0\" encoding=\"utf-8\"?>\
        <mydoc xmlns=\"demo\" id=\"some_id\" name=\"some_name\" some-other-attr=\"other_attr\" />");

    let mut out2:Vec<u8> = Vec::new();
    root.to_writer_with_options(&mut out2, WriteOptions::new()).unwrap();
    assert_eq!(str::from_utf8(&out2).unwrap(), "\
        <?xml version=\"1.0\" encoding=\"utf-8\"?>\
        <mydoc xmlns=\"demo\" id=\"some_id\" name=\"some_name\" some-other-attr=\"other_attr\" />");
```
This tests can randomly fail with a HashMap, because HashMap associate arbitrary keys with an arbitrary value.

Switching to a BTreeMap can resolve this issue.


Signed-off-by: Freyskeyd <simon.paitrault@gmail.com>