### PR TITLE
Add Element::retain_children

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1031,6 +1031,22 @@ impl Element {
         }
     }
 
+    /// Removes all children that don't match a predicate.
+    pub fn retain_children<F>(&mut self, f: F)
+    where
+        F: FnMut(&Element) -> bool,
+    {
+        self.children.retain(f);
+    }
+
+    /// Removes all children that don't match a predicate. The predicate is passed a mutable reference to each element.
+    pub fn retain_children_mut<F>(&mut self, f: F)
+    where
+        F: FnMut(&mut Element) -> bool,
+    {
+        self.children.retain_mut(f);
+    }
+
     /// Appends a new child and returns a reference to self.
     pub fn append_child(&mut self, child: Element) -> &mut Element {
         self.children.push(child);

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -423,3 +423,27 @@ fn test_attr() {
         assert_eq!(child.get_attr("{tag:myns}attr"), None);
     }
 }
+
+#[test]
+fn test_retain() {
+    let mut root = Element::from_reader(
+        r#"<?xml version="1.0"?>
+    <root>
+        <list a="1" b="2" c="3">
+            <item attr="foo1"/>
+            <item attr="foo2"/>
+            <item attr="bar3"/>
+            <item attr="foo4"/>
+            <item attr="bar5"/>
+        </list>
+    </root>
+    "#
+        .as_bytes(),
+    )
+    .unwrap();
+
+    let list = root.find_mut("list").unwrap();
+    list.retain_children(|item| item.get_attr("attr").unwrap().starts_with("foo"));
+
+    assert_eq!(list.children().count(), 3);
+}


### PR DESCRIPTION
Hello, thanks for this library! I needed to do some XML editing and this change made it easier to remove elements without needing to keep track of the index (especially useful when removing multiple elements at a time).

---

Add Element::retain_children and Element::retain_children_mut, analogous to retain() and retain_mut() in Vec.